### PR TITLE
Use the proper TEMP directory on Windows

### DIFF
--- a/lib/elm-format.js
+++ b/lib/elm-format.js
@@ -97,7 +97,7 @@ module.exports = {
     var _this3 = this;
 
     var cursorPosition = editor.getCursorScreenPosition();
-    var tmpFile = _path2.default.join(_os2.default.tmpdir(), '/tmp/elm-format.tmp');
+    var tmpFile = _path2.default.join(_os2.default.tmpdir(), 'elm-format.tmp');
     new _atom.BufferedProcess({
       command: atom.config.get('elm-format.binary'),
       args: [file.path, '--yes', '--output', tmpFile],

--- a/lib/elm-format.js
+++ b/lib/elm-format.js
@@ -15,6 +15,10 @@ var _fs = require('fs');
 
 var _fs2 = _interopRequireDefault(_fs);
 
+var _os = require('os');
+
+var _os2 = _interopRequireDefault(_os);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 module.exports = {
@@ -93,12 +97,13 @@ module.exports = {
     var _this3 = this;
 
     var cursorPosition = editor.getCursorScreenPosition();
+    var tmpFile = _path2.default.join(_os2.default.tmpdir(), '/tmp/elm-format.tmp');
     new _atom.BufferedProcess({
       command: atom.config.get('elm-format.binary'),
-      args: [file.path, '--yes', '--output', '/tmp/elm-format.tmp'],
+      args: [file.path, '--yes', '--output', tmpFile],
       exit: function exit(code) {
         if (code === 0) {
-          _fs2.default.readFile('/tmp/elm-format.tmp', 'utf8', function (err, data) {
+          _fs2.default.readFile(tmpFile, 'utf8', function (err, data) {
             editor.setText(data);
             editor.save();
             editor.setCursorScreenPosition(cursorPosition);

--- a/src/elm-format.js
+++ b/src/elm-format.js
@@ -4,6 +4,7 @@ import { CompositeDisposable, BufferedProcess } from 'atom';
 import path from 'path';
 import config from './settings';
 import fs from 'fs';
+import os from 'os';
 
 module.exports = {
   config,
@@ -77,12 +78,13 @@ module.exports = {
 
   format(file, editor) {
     const cursorPosition = editor.getCursorScreenPosition();
+    const tmpFile = path.join(os.tmpdir(), '/tmp/elm-format.tmp');
     new BufferedProcess({
       command: atom.config.get('elm-format.binary'),
-      args: [file.path, '--yes', '--output', '/tmp/elm-format.tmp'],
+      args: [file.path, '--yes', '--output', tmpFile],
       exit: code => {
         if (code === 0) {
-          fs.readFile('/tmp/elm-format.tmp', 'utf8', (err, data) => {
+          fs.readFile(tmpFile, 'utf8', (err, data) => {
             editor.setText(data);
             editor.save();
             editor.setCursorScreenPosition(cursorPosition);

--- a/src/elm-format.js
+++ b/src/elm-format.js
@@ -78,7 +78,7 @@ module.exports = {
 
   format(file, editor) {
     const cursorPosition = editor.getCursorScreenPosition();
-    const tmpFile = path.join(os.tmpdir(), '/tmp/elm-format.tmp');
+    const tmpFile = path.join(os.tmpdir(), 'elm-format.tmp');
     new BufferedProcess({
       command: atom.config.get('elm-format.binary'),
       args: [file.path, '--yes', '--output', tmpFile],


### PR DESCRIPTION
I ran into some trouble using this plugin on windows, and discovered that it was hard coded to use `/tmp/elm-format.tmp`. Since this isn't a valid path on Windows, I altered it to use `path.join(os.tmpdir(), 'elm-format.tmp')` for the location of the temp file.
