### PR TITLE
Use onWillSave, spawnSync, setTextViaDiff

### DIFF
--- a/lib/elm-format.js
+++ b/lib/elm-format.js
@@ -82,12 +82,7 @@ module.exports = {
 
       if (status === 0) {
         var cursorPosition = editor.getCursorScreenPosition();
-        // const marker = editor.markScreenRange([cursorPosition, cursorPosition], {
-        //   invalidate: 'never', persistent: false
-        // });
         editor.buffer.setTextViaDiff(stdout.toString());
-        // editor.setCursorScreenPosition(marker.getStartScreenPosition());
-        // marker.destroy();
         editor.setCursorScreenPosition(cursorPosition);
 
         this.success('Formatted file');

--- a/lib/elm-format.js
+++ b/lib/elm-format.js
@@ -11,21 +11,15 @@ var _settings = require('./settings');
 
 var _settings2 = _interopRequireDefault(_settings);
 
-var _fs = require('fs');
+var _child_process = require('child_process');
 
-var _fs2 = _interopRequireDefault(_fs);
-
-var _os = require('os');
-
-var _os2 = _interopRequireDefault(_os);
+var _child_process2 = _interopRequireDefault(_child_process);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 module.exports = {
   config: _settings2.default,
   subscriptions: null,
-  // TODO: Some better debounce/throttle function
-  lastSave: Date.now(),
 
   activate: function activate() {
     var _this = this;
@@ -36,26 +30,18 @@ module.exports = {
         return _this.formatCurrentFile();
       }
     }));
-    this.editorObserver = atom.workspace.observeTextEditors(function (e) {
+    this.subscriptions.add(atom.workspace.observeTextEditors(function (e) {
       return _this.handleEvents(e);
-    });
+    }));
   },
   handleEvents: function handleEvents(editor) {
     var _this2 = this;
 
-    editor.getBuffer().onDidSave(function (file) {
-      if (atom.config.get('elm-format.formatOnSave') && _this2.isElmFile(file)) {
-        _this2.debounce(function () {
-          return _this2.format(file, editor);
-        });
+    editor.getBuffer().onWillSave(function () {
+      if (atom.config.get('elm-format.formatOnSave') && _this2.isElmEditor(editor)) {
+        _this2.format(editor);
       }
     });
-  },
-  debounce: function debounce(func) {
-    if (Date.now() - 1000 > this.lastSave) {
-      this.lastSave = Date.now();
-      func();
-    }
   },
   deactivate: function deactivate() {
     this.subscriptions.dispose();
@@ -71,18 +57,12 @@ module.exports = {
     }
   },
   formatCurrentFile: function formatCurrentFile() {
-    var editor = atom.workspace.getActivePaneItem();
-
-    if (!editor || editor.isModified()) {
-      // Abort for invalid or unsaved text editors
-      atom.notifications.addError('Please save before formatting');
+    var editor = atom.workspace.getActiveTextEditor();
+    if (!editor) {
       return;
     }
-
-    var file = editor !== null ? editor.buffer.file : void 0;
-
-    if (this.isElmFile(file)) {
-      this.format(file, editor);
+    if (this.isElmEditor(editor)) {
+      this.format(editor);
     } else {
       atom.notifications.addInfo('Not an Elm file', {
         dismissable: false,
@@ -90,32 +70,32 @@ module.exports = {
       });
     }
   },
-  isElmFile: function isElmFile(file) {
-    return file && _path2.default.extname(file.path) === '.elm';
+  isElmEditor: function isElmEditor(editor) {
+    return editor && editor.getPath && editor.getPath() && _path2.default.extname(editor.getPath()) === '.elm';
   },
-  format: function format(file, editor) {
-    var _this3 = this;
+  format: function format(editor) {
+    try {
+      var _childProcess$spawnSy = _child_process2.default.spawnSync(atom.config.get('elm-format.binary'), ['--stdin'], { input: editor.getText() });
 
-    var cursorPosition = editor.getCursorScreenPosition();
-    var tmpFile = _path2.default.join(_os2.default.tmpdir(), 'elm-format.tmp');
-    new _atom.BufferedProcess({
-      command: atom.config.get('elm-format.binary'),
-      args: [file.path, '--yes', '--output', tmpFile],
-      exit: function exit(code) {
-        if (editor.isAlive()) {
-          if (code === 0) {
-            _fs2.default.readFile(tmpFile, 'utf8', function (err, data) {
-              editor.setText(data);
-              editor.save();
-              editor.setCursorScreenPosition(cursorPosition);
+      var status = _childProcess$spawnSy.status;
+      var stdout = _childProcess$spawnSy.stdout;
 
-              _this3.success('Formatted file');
-            });
-          } else {
-            _this3.error('elm-format exited with code ' + code);
-          }
-        }
+      if (status === 0) {
+        var cursorPosition = editor.getCursorScreenPosition();
+        // const marker = editor.markScreenRange([cursorPosition, cursorPosition], {
+        //   invalidate: 'never', persistent: false
+        // });
+        editor.buffer.setTextViaDiff(stdout.toString());
+        // editor.setCursorScreenPosition(marker.getStartScreenPosition());
+        // marker.destroy();
+        editor.setCursorScreenPosition(cursorPosition);
+
+        this.success('Formatted file');
+      } else {
+        this.error('elm-format exited with code ' + status);
       }
-    });
+    } catch (exception) {
+      this.error('elm-format exception: ' + exception);
+    }
   }
 };

--- a/src/elm-format.js
+++ b/src/elm-format.js
@@ -68,12 +68,7 @@ module.exports = {
         ['--stdin'], { input: editor.getText() });
       if (status === 0) {
         const cursorPosition = editor.getCursorScreenPosition();
-        // const marker = editor.markScreenRange([cursorPosition, cursorPosition], {
-        //   invalidate: 'never', persistent: false
-        // });
         editor.buffer.setTextViaDiff(stdout.toString());
-        // editor.setCursorScreenPosition(marker.getStartScreenPosition());
-        // marker.destroy();
         editor.setCursorScreenPosition(cursorPosition);
 
         this.success('Formatted file');


### PR DESCRIPTION
Hi!  Currently, those using `linter-elm-make` are having issues when they have `elm-format` installed.  It's because `elm-format` is saving the file again, resulting to 2 lints.  There's an `elm-make` bug that's causing warnings to disappear in `linter-elm-make` when the file is saved another time without changes.

This PR tries to remedy the issue by formatting the text in `onWillSave` instead of `onDidSave`.  It also needed the operation to be synchronous, therefore `spawnSync` was used.  Finally, `setTextViaDiff` was used to remove the flicker caused by syntax highlighting computation.

References:
https://github.com/elm-lang/elm-make/issues/114
https://github.com/mybuddymichael/linter-elm-make/issues/81

Sorry if the changes are quite significant.  I'll perfectly understand if you will not accept the PR since it will change the current behavior of `elm-format`.

Thanks!
