### PR TITLE
Update README on installation and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,28 @@
 # elm-format
 
-Runs `elm-format` on save or manually
+Runs `elm-format` on save or manually.
 
-Get `elm-format` at https://github.com/avh4/elm-format
+## Installation
+
+1. Get `elm-format` at https://github.com/avh4/elm-format
+2. Install Atom package via Atom's UI or
+   
+```
+apm install elm-format
+```
+
+## Configuration
+
+**⚠️ Note:** If you've got the `elm-format` binary on any other path than the default `/usr/local/bin/elm-format`, you need to configure the `binary` flag in your Atom config for this package. Otherwise, the package won't run.
+
+In your Atom config file:
+
+```cson
+# ...
+
+"elm-format":
+    binary: "/usr/local/bin/elm-format" # Needs /to/be/absolute
+    formatOnSave: true
+    showNotifications: false
+    showErrorNotifications: true
+```


### PR DESCRIPTION
I had to go through the source to see that I need to config an absolute path to `elm-format`, so I made a suggestion for the README.

Sidenote: shouldn't it be easy to add a settings panel in Atom for this? I can see the `settings.js` file but no option in Atom for showing package settings.