### PR TITLE
Use "elm-format" as the default binary path

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -5,7 +5,7 @@ export default {
     title: 'Binary path',
     description: 'Path for elm-format',
     type: 'string',
-    default: '/usr/local/bin/elm-format',
+    default: 'elm-format',
     order: 1,
   },
   formatOnSave: {


### PR DESCRIPTION
Not all people have elm-format installed into /usr/local/bin/elm-format (I installed it via package manager so it's in /usr/bin/elm-format), but I assume most of the people have it int their PATH. This should fix #18 for most users.