### PR TITLE
Better error messages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,5 +6,8 @@
   "env": {
     "es6": true,
     "node": true
+  },
+  "rules": {
+    "import/prefer-default-export": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "opn": "^5.0.0"
+  },
   "devDependencies": {
     "eslint": "^3.14.0",
     "eslint-config-airbnb-base": "^11.0.1",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,13 @@
+'use babel';
+
+import open from 'opn';
+
+export const installInstructions = {
+  buttons: [{
+    className: 'btn btn-error',
+    onDidClick: () => {
+      open('https://github.com/avh4/elm-format#atom-elm-format-installation');
+    },
+    text: 'Open instructions',
+  }],
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 import { CompositeDisposable } from 'atom'; // eslint-disable-line
 import path from 'path';
 import childProcess from 'child_process';
+import fs from 'fs';
 import config from './settings';
 
 export default {
@@ -63,8 +64,9 @@ export default {
 
   format(editor) {
     try {
+      const binary = atom.config.get('elm-format.binary');
       const { status, stdout } = childProcess.spawnSync(
-        atom.config.get('elm-format.binary'),
+        binary,
         ['--stdin'], { input: editor.getText() });
       switch (status) {
         case 0: {
@@ -79,7 +81,11 @@ export default {
           this.error('Can\'t format, syntax error maybe?');
           break;
         case null:
-          this.error('Can\'t find elm-format binary, check your settings');
+          if (fs.existsSync(binary)) {
+            this.error('Can\'t execute the elm-format binary, is it executable?');
+          } else {
+            this.error('Can\'t find the elm-format binary, check the "elm-format" package settings page');
+          }
           break;
         default:
           this.error(`elm-format exited with code ${status}.`);

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import path from 'path';
 import childProcess from 'child_process';
 import fs from 'fs';
 import config from './settings';
+import { installInstructions } from './helpers';
 
 export default {
   config,
@@ -30,9 +31,9 @@ export default {
     this.subscriptions.dispose();
   },
 
-  error(str) {
+  error(str, options = {}) {
     if (atom.config.get('elm-format.showErrorNotifications')) {
-      atom.notifications.addError(str);
+      atom.notifications.addError(str, options);
     }
   },
 
@@ -82,9 +83,9 @@ export default {
           break;
         case null:
           if (fs.existsSync(binary)) {
-            this.error('Can\'t execute the elm-format binary, is it executable?');
+            this.error('Can\'t execute the elm-format binary, is it executable?', installInstructions);
           } else {
-            this.error('Can\'t find the elm-format binary, check the "elm-format" package settings page');
+            this.error('Can\'t find the elm-format binary, check the "elm-format" package settings page', installInstructions);
           }
           break;
         default:


### PR DESCRIPTION
Check if binary exists before saying it's missing. If it exists we assume it can't be executed (and display that as an error).

<img width="488" alt="screen shot 2017-06-02 at 11 31 42" src="https://cloud.githubusercontent.com/assets/430872/26720087/27844322-4787-11e7-9892-b68992c79d28.png">

The button links to https://github.com/avh4/elm-format#atom-elm-format-installation

cc @avh4 Does this qualify for the error handling column?