### PR TITLE
Add option to resolve elm-format binary from local project directory

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -14,21 +14,38 @@ export const installInstructions = {
   }],
 };
 
-const findElmFormatBinary = (dir) => {
-  const elmFormatFile = path.join(dir, 'node_modules', '.bin', 'elm-format');
-
+const fileExists = (filePath) => {
   try {
-    fs.accessSync(elmFormatFile, fs.constants.F_OK);
-    return elmFormatFile;
+    fs.accessSync(filePath, fs.constants.F_OK);
+    return true;
   } catch (e) {
     return false;
   }
 };
 
+const findLocalElmFormat = (dir) => {
+  const localBinary = path.join(dir, 'node_modules', '.bin', 'elm-format');
+  const elmPackageFile018 = path.join(dir, 'elm-package.json');
+  const elmPackageFile019 = path.join(dir, 'elm.json');
+  let localElmVersion = false;
+
+  if (fileExists(elmPackageFile018)) {
+    localElmVersion = '0.18';
+  } else if (fileExists(elmPackageFile019)) {
+    localElmVersion = '0.19';
+  }
+
+  if (fileExists(localBinary) && localElmVersion) {
+    return { localBinary, localElmVersion };
+  }
+
+  return false;
+};
+
 export const resolveLocalBinary = () => {
   const projectPaths = atom.project.getPaths();
   const results = projectPaths
-    .map(findElmFormatBinary)
+    .map(findLocalElmFormat)
     .filter(a => a !== false);
 
   if (results && results[0]) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,7 @@
 'use babel';
 
+import fs from 'fs';
+import path from 'path';
 import open from 'opn';
 
 export const installInstructions = {
@@ -10,4 +12,28 @@ export const installInstructions = {
     },
     text: 'Open instructions',
   }],
+};
+
+const findElmFormatBinary = (dir) => {
+  const elmFormatFile = path.join(dir, 'node_modules', '.bin', 'elm-format');
+
+  try {
+    fs.accessSync(elmFormatFile, fs.constants.F_OK);
+    return elmFormatFile;
+  } catch (e) {
+    return false;
+  }
+};
+
+export const resolveLocalBinary = () => {
+  const projectPaths = atom.project.getPaths();
+  const results = projectPaths
+    .map(findElmFormatBinary)
+    .filter(a => a !== false);
+
+  if (results && results[0]) {
+    return results[0];
+  }
+
+  return false;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -86,11 +86,11 @@ export default {
       let elmVersion = atom.config.get('elm-format.elmVersion') || '0.19';
 
       if (atom.config.get('elm-format.preferLocalBinary')) {
-        const localBinary = resolveLocalBinary();
+        const { localBinary, localElmVersion } = resolveLocalBinary();
 
-        if (localBinary) {
+        if (localBinary && localElmVersion) {
           binary = localBinary;
-          elmVersion = false;
+          elmVersion = localElmVersion;
         }
       }
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -13,7 +13,7 @@ export default {
     description: 'The version of Elm to use when formatting.',
     type: 'string',
     default: '0.19',
-    enum: ['0.18', '0.19']
+    enum: ['0.18', '0.19'],
   },
   formatOnSave: {
     title: 'Format on save',
@@ -41,6 +41,6 @@ export default {
     description: 'If a syntax error is encountered, automatically focus the cursor on the line with the error.',
     type: 'boolean',
     default: true,
-    order: 2
-  }
+    order: 2,
+  },
 };

--- a/src/settings.js
+++ b/src/settings.js
@@ -6,6 +6,13 @@ export default {
     description: 'Path for elm-format',
     type: 'string',
     default: 'elm-format',
+    order: 7,
+  },
+  preferLocalBinary: {
+    title: 'Prefer local binary',
+    description: 'Try to resolve the binary from the current project\'s directories if possible',
+    type: 'boolean',
+    default: false,
     order: 6,
   },
   elmVersion: {


### PR DESCRIPTION
I have different projects that use different versions of elm-format. This new option will help avoid formatting with the wrong version by checking for an `elm-format` binary in the project's local node_modules folder.

The linting fixes might also fix #24.